### PR TITLE
Create Glossary Page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,8 @@ favicon: /assets/images/icon.png
 
 # Set links to grouping pages if you want to use them
 tag_page: /tags
+family_page: /families
+glossary_page: /glossary
 
 # Contact Settings
 contact:

--- a/_data/glossary.json
+++ b/_data/glossary.json
@@ -11,6 +11,8 @@
     },
     "weave": {
         "image": "/assets/images/posts/2024_05_26_japanese_4_in_1/japanese_4_in_1_flat.jpg",
+        "height": "250",
+        "width": "250",
         "caption": "The Japanese 4-in-1 weave, a very basic weave.",
         "text": "In chainmail a weave is an infinitely repeating pattern and unique of rings, where each ring meaningfully contributes such that removing one ring drastically changes its characteristics.",
         "glossary_page_show": true

--- a/_data/glossary.json
+++ b/_data/glossary.json
@@ -12,13 +12,16 @@
     "weave": {
         "image": "/assets/images/posts/2024_05_26_japanese_4_in_1/japanese_4_in_1_flat.jpg",
         "caption": "The Japanese 4-in-1 weave, a very basic weave.",
-        "text": "In chainmail a weave is an infinitely repeating pattern and unique of rings, where each ring meaningfully contributes such that removing one ring drastically changes its characteristics."
+        "text": "In chainmail a weave is an infinitely repeating pattern and unique of rings, where each ring meaningfully contributes such that removing one ring drastically changes its characteristics.",
+        "glossary_page_show": true
     },
     "chain": {
-        "text": "In chainmail a chain is a weave that is infinitely repeatable in one direction."
+        "text": "In chainmail a chain is a weave that is infinitely repeatable in one direction.",
+        "glossary_page_show": true
     },
     "sheet": {
-        "text": "In chainmail a sheet is a weave that is infinitely repeatable in two directions that are perpendicular to each other."
+        "text": "In chainmail a sheet is a weave that is infinitely repeatable in two directions that are perpendicular to each other.",
+        "glossary_page_show": true
     },
     "tutorial": {
         "text": "Posts with included tutorials."

--- a/_data/glossary.json
+++ b/_data/glossary.json
@@ -31,5 +31,21 @@
     "aspect_ratio": {
         "text": "The Aspect Ratio(AR) of is how large a ring is(relative to its wire thickness) with a larger AR meaning a larger ring. It is calculated as Inner Diameter/Wire Diameter.",
         "glossary_page_show": true
+    },
+    "inner_diameter": {
+        "text": "The Inner Diameter(ID) of a ring is the diameter of the circle formed by the inside edge of a ring.",
+        "glossary_page_show": true
+    },
+    "wire_diameter": {
+        "text": "The Wire Diameter(WD) of a ring is the distance from the inner edge of the ring to the closest point on the outer edge of the ring.",
+        "glossary_page_show": true
+    },
+    "standard_wire_gauge": {
+        "text": "Standard Wire Gauge(sWG) is a wire guage system that assigns a number to a specified thickness (Wire Diameter) of wire with a thicker wire having a smaller gauge. You can read more about it <a href=\"https://en.wikipedia.org/wiki/Standard_wire_gauge\">here</a>.",
+        "glossary_page_show": true
+    },
+    "american_wire_gauge": {
+        "text": "American Wire Gauge(AWG) is a wire guage system that assigns a number to a specified thickness (Wire Diameter) of wire with a thicker wire having a smaller gauge. You can read more about it <a href=\"https://en.wikipedia.org/wiki/American_wire_gauge\">here</a>.",
+        "glossary_page_show": true
     }
 }

--- a/_data/glossary.json
+++ b/_data/glossary.json
@@ -28,7 +28,7 @@
     "tutorial": {
         "text": "Posts with included tutorials."
     },
-    "aspect ratio": {
+    "aspect_ratio": {
         "text": "The Aspect Ratio(AR) of is how large a ring is(relative to its wire thickness) with a larger AR meaning a larger ring. It is calculated as Inner Diameter/Wire Diameter.",
         "glossary_page_show": true
     }

--- a/_data/glossary.json
+++ b/_data/glossary.json
@@ -25,5 +25,9 @@
     },
     "tutorial": {
         "text": "Posts with included tutorials."
+    },
+    "aspect ratio": {
+        "text": "The Aspect Ratio(AR) of is how large a ring is(relative to its wire thickness) with a larger AR meaning a larger ring. It is calculated as Inner Diameter/Wire Diameter.",
+        "glossary_page_show": true
     }
 }

--- a/_includes/abbreviations/ar.html
+++ b/_includes/abbreviations/ar.html
@@ -1,0 +1,1 @@
+<abbr title='' data-tippy-content="Aspect Ratio <a href=&quot;{{ site.baseurl }}{{ site.glossary_page }}#aspect_ratio&quot;>(Definition)</a> ">AR</abbr>

--- a/_includes/abbreviations/awg.html
+++ b/_includes/abbreviations/awg.html
@@ -1,0 +1,1 @@
+<abbr title='' data-tippy-content="American Wire Gauge <a href=&quot;{{ site.baseurl }}{{ site.glossary_page }}#american_wire_gauge&quot;>(Definition)</a> ">AWG</abbr>

--- a/_includes/abbreviations/id.html
+++ b/_includes/abbreviations/id.html
@@ -1,0 +1,1 @@
+<abbr title='' data-tippy-content="Inner Diameter <a href=&quot;{{ site.baseurl }}{{ site.glossary_page }}#inner_diameter&quot;>(Definition)</a> ">ID</abbr>

--- a/_includes/abbreviations/swg.html
+++ b/_includes/abbreviations/swg.html
@@ -1,0 +1,1 @@
+<abbr title='' data-tippy-content="Standard Wire Gauge <a href=&quot;{{ site.baseurl }}{{ site.glossary_page }}#standard_wire_gauge&quot;>(Definition)</a> ">SWG</abbr>

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -20,6 +20,6 @@
   <!-- Setup Tippy -->
   <script src="https://unpkg.com/@popperjs/core@2"></script>
   <script src="https://unpkg.com/tippy.js@6"></script>
-  <script>tippy('[data-tippy-content]', {interactive: true,});</script>
+  <script>tippy('[data-tippy-content]', {interactive: true, allowHTML: true, touch: true,});</script>
 
 </html>

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -1,0 +1,36 @@
+---
+layout: base
+---
+
+
+<!-- Items -->
+<div class="tags">
+    {% for definition in site.data.glossary %}
+        {% if definition[1].glossary_page_show %}
+            <a href="#{{ definition[0 ]}}"> {{ definition[0] | capitalize }} </a>
+        {% endif %}
+    {% endfor %}
+</div>
+
+
+<!-- Definitions -->
+{%- for definition in site.data.glossary -%}
+    {% if definition[1].glossary_page_show %}
+        <div class="tag-title">
+            <span id="{{ definition[0] }}">{{ definition[0] | capitalize }}</span>
+        </div>
+        {%- if definition[1].image -%}
+            <figure>
+                <img src="{{ site.baseurl }}{{ definition[1].image }}" alt="{{ definition[1].caption }}">
+                {%- if definition[1].caption -%}
+                    <figcaption>{{ definition[1].caption }}</figcaption>
+                {%- endif -%}
+            </figure>
+        {%- else -%}
+            <br>
+        {%- endif -%}
+        {{ definition[1].text }}
+        <br>
+        <br>
+    {%- endif -%}
+{%- endfor -%}

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -10,7 +10,7 @@ layout: base
 
             <!-- Capitalize Name -->
             {%- assign name = "" -%}
-            {%- assign components = definition[0] | split: " " -%}
+            {%- assign components = definition[0] | split: "_" -%}
             {%- for component in components -%}
                 {%- assign tmp = component | capitalize -%}
                 {%- assign tmp = tmp | append: " " -%}
@@ -29,7 +29,7 @@ layout: base
         <div id="{{ definition[0] }}-container"" class="tag-container">
             <!-- Capitalize Name -->
             {%- assign name = "" -%}
-            {%- assign components = definition[0] | split: " " -%}
+            {%- assign components = definition[0] | split: "_" -%}
             {%- for component in components -%}
                 {%- assign tmp = component | capitalize -%}
                 {%- assign tmp = tmp | append: " " -%}

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -40,20 +40,26 @@ layout: base
                 <span id="{{ definition[0] }}">{{ name }}</span>
             </div>
 
-            {%- if definition[1].image -%}
-                <figure>
-                    <img src="{{ site.baseurl }}{{ definition[1].image }}" alt="{{ definition[1].caption }}">
-                    {%- if definition[1].caption -%}
-                        <figcaption>{{ definition[1].caption }}</figcaption>
-                    {%- endif -%}
-                </figure>
-            {%- else -%}
-                <br>
-            {%- endif -%}
-            
-            {{ definition[1].text }}
-            <br>
-            <br>
+
+            <div class="glossary-item">
+                {%- if definition[1].image -%}
+                    <div class="glossary-image">
+                        <figure>
+                            <img src="{{ site.baseurl }}{{ definition[1].image }}" alt="{{ definition[1].caption }}" width="{{ definition[1].width }}" height="{{ definition[1].height }}">
+                            {%- if definition[1].caption -%}
+                                <figcaption>{{ definition[1].caption }}</figcaption>
+                            {%- endif -%}
+                        </figure>
+                    </div>
+                {%- else -%}
+                    <br>
+                {%- endif -%}
+
+
+                <div class="glossary-definiton">
+                    <span>{{ definition[1].text }}</span>
+                </div>
+            </div>
         </div>
     {%- endif -%}
 {%- endfor -%}

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -7,7 +7,17 @@ layout: base
 <div class="tags">
     {% for definition in site.data.glossary %}
         {% if definition[1].glossary_page_show %}
-            <a href="#{{ definition[0 ]}}"> {{ definition[0] | capitalize }} </a>
+
+            <!-- Capitalize Name -->
+            {%- assign name = "" -%}
+            {%- assign components = definition[0] | split: " " -%}
+            {%- for component in components -%}
+                {%- assign tmp = component | capitalize -%}
+                {%- assign tmp = tmp | append: " " -%}
+                {%- assign name = name | append: tmp -%}
+            {%- endfor -%}
+
+            <a href="#{{ definition[0] }}"> {{ name }} </a>
         {% endif %}
     {% endfor %}
 </div>
@@ -16,8 +26,19 @@ layout: base
 <!-- Definitions -->
 {%- for definition in site.data.glossary -%}
     {% if definition[1].glossary_page_show %}
+
+
+        <!-- Capitalize Name -->
+        {%- assign name = "" -%}
+        {%- assign components = definition[0] | split: " " -%}
+        {%- for component in components -%}
+            {%- assign tmp = component | capitalize -%}
+            {%- assign tmp = tmp | append: " " -%}
+            {%- assign name = name | append: tmp -%}
+        {%- endfor -%}
+
         <div class="tag-title">
-            <span id="{{ definition[0] }}">{{ definition[0] | capitalize }}</span>
+            <span id="{{ definition[0] }}">{{ name }}</span>
         </div>
         {%- if definition[1].image -%}
             <figure>

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -5,7 +5,8 @@ layout: base
 
 <!-- Items -->
 <div class="tags hide-in-solo">
-    {% for definition in site.data.glossary %}
+    {% assign sorted_definitions = site.data.glossary | sort %}
+    {% for definition in sorted_definitions %}
         {% if definition[1].glossary_page_show %}
 
             <!-- Capitalize Name -->
@@ -24,7 +25,8 @@ layout: base
 
 
 <!-- Definitions -->
-{%- for definition in site.data.glossary -%}
+{% assign sorted_definitions = site.data.glossary | sort %}
+{%- for definition in sorted_definitions -%}
     {% if definition[1].glossary_page_show %}
         <div id="{{ definition[0] }}-container"" class="tag-container">
             <!-- Capitalize Name -->

--- a/_layouts/glossary.html
+++ b/_layouts/glossary.html
@@ -4,7 +4,7 @@ layout: base
 
 
 <!-- Items -->
-<div class="tags">
+<div class="tags hide-in-solo">
     {% for definition in site.data.glossary %}
         {% if definition[1].glossary_page_show %}
 
@@ -26,32 +26,81 @@ layout: base
 <!-- Definitions -->
 {%- for definition in site.data.glossary -%}
     {% if definition[1].glossary_page_show %}
+        <div id="{{ definition[0] }}-container"" class="tag-container">
+            <!-- Capitalize Name -->
+            {%- assign name = "" -%}
+            {%- assign components = definition[0] | split: " " -%}
+            {%- for component in components -%}
+                {%- assign tmp = component | capitalize -%}
+                {%- assign tmp = tmp | append: " " -%}
+                {%- assign name = name | append: tmp -%}
+            {%- endfor -%}
 
+            <div class="tag-title">
+                <span id="{{ definition[0] }}">{{ name }}</span>
+            </div>
 
-        <!-- Capitalize Name -->
-        {%- assign name = "" -%}
-        {%- assign components = definition[0] | split: " " -%}
-        {%- for component in components -%}
-            {%- assign tmp = component | capitalize -%}
-            {%- assign tmp = tmp | append: " " -%}
-            {%- assign name = name | append: tmp -%}
-        {%- endfor -%}
-
-        <div class="tag-title">
-            <span id="{{ definition[0] }}">{{ name }}</span>
-        </div>
-        {%- if definition[1].image -%}
-            <figure>
-                <img src="{{ site.baseurl }}{{ definition[1].image }}" alt="{{ definition[1].caption }}">
-                {%- if definition[1].caption -%}
-                    <figcaption>{{ definition[1].caption }}</figcaption>
-                {%- endif -%}
-            </figure>
-        {%- else -%}
+            {%- if definition[1].image -%}
+                <figure>
+                    <img src="{{ site.baseurl }}{{ definition[1].image }}" alt="{{ definition[1].caption }}">
+                    {%- if definition[1].caption -%}
+                        <figcaption>{{ definition[1].caption }}</figcaption>
+                    {%- endif -%}
+                </figure>
+            {%- else -%}
+                <br>
+            {%- endif -%}
+            
+            {{ definition[1].text }}
             <br>
-        {%- endif -%}
-        {{ definition[1].text }}
-        <br>
-        <br>
+            <br>
+        </div>
     {%- endif -%}
 {%- endfor -%}
+
+
+{%- if page.show_single -%}
+    <script>
+        // Determine how many anchors are in the url
+        url_parts = document.URL.split('#');
+        switch (url_parts.length) {
+
+            // No Anchor
+            case 1:
+                // Log and exit case
+                console.log('No Anchor');
+                break;
+
+            // 1 Anchor
+            case 2:
+                console.log('Has anchor');
+
+                // Hide all hideable items other than tag containers
+                items_to_hide = document.querySelectorAll(".hide-in-solo");
+                for (item of items_to_hide) {
+                    item.style.display = "none";
+                }
+
+                // Hide all containers
+                containers = document.querySelectorAll('div.tag-container');
+                for (container of containers) {
+                    container.style.display = 'none';
+                }
+                console.log('Hid all containers');
+                
+                // Show desired container
+                anchor = url_parts[1];
+                document.querySelector('div#'+anchor+'-container').style.display = 'block';
+                console.log('Show desired container');
+
+                // Exiting case
+                break;
+
+            // Anchors > 1
+            default:
+                console.log("Please don't submit  unsafe urls");
+                break;
+        }
+    </script>
+{%- endif -%}
+

--- a/_layouts/list_tags.html
+++ b/_layouts/list_tags.html
@@ -6,7 +6,8 @@ layout: base
 <h1 class="hide-in-solo">Post Tags</h1>
 
 <div class="tags hide-in-solo">
-    {% for tag in site.tags %}
+    {% assign sorted_tags = site.tags | sort %}
+    {% for tag in sorted_tags %}
         <a href="#{{ tag[0] }}"> {{ tag[0] }} </a>
     {% endfor %}
 </div>
@@ -15,7 +16,8 @@ layout: base
 <!-- List posts by type -->
 <h1 class="hide-in-solo">Tag Lists</h1>
 
-{%- for tag in site.tags -%}
+{% assign sorted_tags = site.tags | sort %}
+{%- for tag in sorted_tags -%}
 
     <div class="tag-container" id="{{ tag[0] }}-container">
         <div class="tag-title">

--- a/_posts/2023-02-12-european_4_in_1.md
+++ b/_posts/2023-02-12-european_4_in_1.md
@@ -14,7 +14,7 @@ Recently, I discovered a wonderful [tutorial](https://www.mailleartisans.org/art
 
 ### Materials
 
-For the sample piece featured in this post, I used 16 SWG rings with a 1/4" internal diameter and an aspect ratio of 4.03, made of bright aluminum. These rings were obtained from [The Ring Lord](https://theringlord.com/).
+For the sample piece featured in this post, I used 16 {% include abbreviations/swg.html %} rings with a 1/4" {% include abbreviations/id.html %} and an {% include abbreviations/ar.html %} of 4.03, made of bright aluminum. These rings were obtained from [The Ring Lord](https://theringlord.com/).
 
 ### Notes
 

--- a/_sass/minima/_glossary_page.scss
+++ b/_sass/minima/_glossary_page.scss
@@ -1,0 +1,25 @@
+
+div.glossary-item {
+    display: flex;
+}
+
+div.glossary-image {
+    height: 100%;
+    width:  100%;
+    // padding-right: 1.5rem;
+
+    // Ensure that the figure caption does not go past the image
+    figure {
+        display: table;
+    }
+    figcaption {
+        display: table-caption;
+        caption-side: bottom;
+        text-align: center;
+    }
+}
+
+div.glossary-definiton {
+    flex-grow: 1;
+    align-content: center;
+}

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -3,4 +3,5 @@
 
 @import '_contact_form.scss',
     '_family_page.scss',
-    '_home_pictures.scss';
+    '_home_pictures.scss',
+    '_glossary_page.scss';

--- a/glossary.md
+++ b/glossary.md
@@ -2,4 +2,5 @@
 layout: glossary
 permalink: /glossary/
 title: Glossary
+show_single: yes
 ---

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,5 @@
+---
+layout: glossary
+permalink: /glossary/
+title: Glossary
+---


### PR DESCRIPTION
The purpose of this pull request is to add a Glossary page template.

The `glossary.html` layout builds a glossary page from marked items in a provided `glossary.json` file. The glossary items may contain an optional image with optional caption. Additionally, the glossary supports the ability to view a single item if linked to the page with an anchor.

Additionally, certain includes have been written for convenience in writing posts.

Finally, this pr also includes a test Glossary page and updates to the European 4-in-1 post testing the includes which test the glossary items.