### PR TITLE
Update Gallery and Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I have created this fork of the [minima](https://github.com/jekyll/minima) Jekyl
 
 ## Special Post Front Matter Variables
 
-* families: A yaml list of the weave familes a post is part of. This is primarily used by the [Family Page](#TODO) and is only applicable for posts representing specific chainmail weaves.
+* families: A yaml list of the weave familes a post is part of. This is primarily used by the [Family Page](#list-families) and is only applicable for posts representing specific chainmail weaves.
 * image_path: The relative path to the folder containing images for the post. I suggest using this in links to images in the post to allow you move the folder easily.
 * main_image: The name of the file in the folder from the `image_path` to use as the main image for the post in the [RSS Feed](#rss-feed), and as the thumbnail image in all places where posts are listed.
 * main_image_width: The width of the image to use for the `main_image` for the post in the [RSS Feed](#rss-feed).
@@ -22,6 +22,10 @@ I have created this fork of the [minima](https://github.com/jekyll/minima) Jekyl
 This layout creates a responsive grid of gallery cards for each post with a link to a folder containing at least 1 displayable image. 
 Each gallery card contains a carousel with dots denoting the active image as well as the post release date, title(as a link) and the tags of the post.
 
+**Optional Post Front Matter Variables:**
+
+* exclude_from_gallery: Set to any value if you wish to exclude this post from the [Gallery](#gallery).
+
 
 **Special Front Matter Variables:**
 
@@ -32,6 +36,7 @@ Each gallery card contains a carousel with dots denoting the active image as wel
 **Requreiments:**
 
 * Posts need to have an `image_path` front matter variable defined to be included.
+
 
 ### RSS Feed
 
@@ -52,6 +57,23 @@ This layout generates an atom feed that is inteded to replace the jekyll-feed ad
 * **feed.logo:** You can specify a relative link to the image you want to be used as the logo in the feed if not specified no logo will be included.
 * **feed.path:** The relative path to the feed, this is used to create a link in the `head` of each page to enable automated discovery this link will not be generated if this is left blank.
 * **feed.url:** The host domain (without baseurl) of the website. This was included as I found that `site.url` doesn't work properly on github pages.
+
+
+### List Families
+
+This layout creates a way to view posts by weave family for posts that include values in the optional `families` variable. The page includes a cloud of clickable tags at the front where each one will take you to the list of posts in that family. Additionally, it can also be set up to display a list of weaves in just a single family when linked to.
+
+
+**Optional Post Front Matter Variables:**
+
+* families: A yaml list of the weave familes a post is part of. This is used to identify the weave families the post should be in the lists of.
+
+**Special Front Matter Variables:**
+* glossary: This has various effects based on which of the values below the variable is set to.
+    * single_only: If set to this value it will attempt to find text from a provided `glossary.json` data file for the family to display with each family, but hide this data when viewed for all families (conditional on the value of `show_single`).
+    * all_only: If set to this value it will attempt to find text from a provided `glossary.json` data file for the family to display with each family, but hide this data when viewed for a single family (conditional on the value of `show_single`).
+    * non-nil: If set to any value other than `nil` it will attempt to find text from a provided `glossary.json` data file for the family to display with each family.
+* show_single: If set to a truthy value it will enable a script that will hide the title, tag cloud, and lists for other families when the page is linked to with an anchor to one of the families.
 
 
 ## Custom Includes

--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ I have created this fork of the [minima](https://github.com/jekyll/minima) Jekyl
 
 # How To Use
 
+## Special Post Front Matter Variables
+
+* families: A yaml list of the weave familes a post is part of. This is primarily used by the [Family Page](#TODO) and is only applicable for posts representing specific chainmail weaves.
+* image_path: The relative path to the folder containing images for the post. I suggest using this in links to images in the post to allow you move the folder easily.
+* main_image: The name of the file in the folder from the `image_path` to use as the main image for the post in the [RSS Feed](#rss-feed), and as the thumbnail image in all places where posts are listed.
+* main_image_width: The width of the image to use for the `main_image` for the post in the [RSS Feed](#rss-feed).
+* main_image_height: The heighty of the image to use for the `main_image` for the post in the [RSS Feed](#rss-feed).
+* exclude_from_gallery: Set to any value if you wish to exclude this post from the [Gallery](#gallery).
+
+
 ## Custom Layouts
 
 ### Gallery

--- a/_layouts/gallery.html
+++ b/_layouts/gallery.html
@@ -32,7 +32,9 @@ Requreiments:
 
 <div class="gallery">
     {%- for post in site.posts -%}
-        {%- include gallery_card.html -%}
+        {%- if post.exclude_from_gallery == nil -%}
+            {%- include gallery_card.html -%}
+        {%- endif -%}
     {%- endfor -%}
 </div>
 

--- a/_posts/2023-10-08-jacobs-ladder.md
+++ b/_posts/2023-10-08-jacobs-ladder.md
@@ -6,6 +6,7 @@ families: European
 image_path: "/assets/images/posts/2023_10_08_jacobs_ladder"
 main_image: "/jacobs_ladder_flat.jpg"
 tags: weave chain spiral
+exclude_from_gallery: True
 ---
 
 ### Overview


### PR DESCRIPTION
The purpose of this post is to update the Gallery layout to respond to a custom front matter variable in posts to allow for post level hiding from the gallery. This was motivated by my analysis posts which having no chainmail images don't make sense to include in the gallery.

In addition I have also improved the documentation in the README file as well.